### PR TITLE
Fixes makefile test for GCC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ export CC		:=	clang
 export AR		:=	llvm-ar
 export OBJCOPY	:=	objcopy
 
-ifdef GCC
+ifeq ($(CXX),g++)
   export CC		:=	gcc
   export AR		:=	ar
 endif


### PR DESCRIPTION
The "ifdef GCC" check doesn't seem to work anymore, causing the build to fail if clang isn't installed. On my system (Ubuntu 19.10), the build still fails even if clang is installed, but this fix at least allows the GCC build to succeed.